### PR TITLE
increase default buffer size to 8192

### DIFF
--- a/archivers/zip/src/main/java/kala/compress/archivers/zip/ZipArchiveReader.java
+++ b/archivers/zip/src/main/java/kala/compress/archivers/zip/ZipArchiveReader.java
@@ -205,6 +205,8 @@ public class ZipArchiveReader implements Closeable {
 
     private static final EnumSet<StandardOpenOption> READ = EnumSet.of(StandardOpenOption.READ);
 
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+
     private static final int HASH_SIZE = 509;
     static final int NIBLET_MASK = 0x0f;
     static final int BYTE_SHIFT = 8;
@@ -711,7 +713,7 @@ public class ZipArchiveReader implements Closeable {
         this.useUnicodeExtraFields = useUnicodeExtraFields;
         this.archive = channel instanceof DataInputSeekableChannel dataInputSeekableChannel && dataInputSeekableChannel.byteOrder() == ByteOrder.LITTLE_ENDIAN
                 ? dataInputSeekableChannel
-                : new BufferedDataInputSeekableChannel(channel, 512, ByteOrder.LITTLE_ENDIAN);
+                : new BufferedDataInputSeekableChannel(channel, DEFAULT_BUFFER_SIZE, ByteOrder.LITTLE_ENDIAN);
         this.rawFileChannel = channel instanceof FileChannel fileChannel ? fileChannel : null;
         boolean success = false;
         try {


### PR DESCRIPTION
粗略地用Spark做了记录，HMCL加载模组列表的时间从7秒多降低到4秒多：https://spark.lucko.me/L2z6gfbrOb

<img width="1348" height="310" alt="image" src="https://github.com/user-attachments/assets/1d334082-4133-4cf1-b413-73846c0f3e7e" />

8192这个值是参照BufferedReader设置的，在zip读取的情境下没有什么特别意义。减小这个值（比如4096）会导致可感的时间增加，增加这个值（比如16384）可以进一步减少加载时间，但是不明显

## Summary by Sourcery

Enhancements:
- Introduce a shared DEFAULT_BUFFER_SIZE constant (8192 bytes) for buffered ZIP channel reads and use it instead of the previous smaller buffer.